### PR TITLE
Bugfix path not defined when calling YaraSource

### DIFF
--- a/yara_validator/yara_validator.py
+++ b/yara_validator/yara_validator.py
@@ -164,7 +164,7 @@ class YaraValidator:
                 and include_name is None:
             self._register_rule(path)
         else:
-            yara_rule = YaraSource(false=path,
+            yara_rule = YaraSource(path=path,
                                    namespace=namespace,
                                    include_name=include_name,
                                    buffer_dir=self._includes_tmp_dir,


### PR DESCRIPTION
Error received when running add_rule_file().  

>>> validator.add_rule_file('/code/yara-rules/test1.yara', 'namespace-1')
Traceback (most recent call last):
  File "<stdin>", line 1, in <module>
  File "/usr/local/lib/python3.8/site-packages/yara_validator/yara_validator.py", line 167, in add_rule_file
    yara_rule = YaraSource(false=path,
  File "/usr/local/lib/python3.8/site-packages/yara_validator/yara_validator.py", line 33, in __init__
    raise SyntaxError('Expected either source or path (none or both '
SyntaxError: Expected either source or path (none or both were provided)

